### PR TITLE
Use digest for Chainguard Image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/jre:openjdk-17
+FROM cgr.dev/chainguard/jre:openjdk-17@sha256:9569fbf8a7d936451f7cb9f720ccaa1ce8524c6685711e52e99f8e83751ea544
 
 COPY build/libs/*.jar /app/
 


### PR DESCRIPTION
We're making some changes to the public tier of Chainguard Images.

Starting August 16, 2023 public users will no longer be able to pull images from our registry (cgr.dev/chainguard) by tags other than latest or latest-dev. Please see [the announcement](https://www.chainguard.dev/unchained/scaling-chainguard-images-with-a-growing-catalog-and-proactive-security-updates) for more information.

This PR will move your JRE image to use a digest that will continue to work post August 16th.

Please see [the migration guide](https://www.chainguard.dev/unchained/a-guide-on-how-to-use-chainguard-images-for-public-catalog-tier-users) for full details on your options.